### PR TITLE
From collection to sequence in Parser

### DIFF
--- a/src/QuizData.Parser/Parser.cs
+++ b/src/QuizData.Parser/Parser.cs
@@ -183,7 +183,6 @@ namespace QuizData.Parser
 
 		public IEnumerable<PersonTestResult> ParseStream(Stream stream)
 		{
-			var result = new List<PersonTestResult>();
 			Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 			using (_reader = new StreamReader(stream, Encoding.GetEncoding(866)))
 			{
@@ -195,10 +194,9 @@ namespace QuizData.Parser
 					var test = ReadTest();
 					if (test == null)
 						continue;
-					result.Add(test);
+					yield return test;
 				}
 			}
-			return result;
 		}
 	}
 }

--- a/test/QuizData.Parser.Test/CsvParserTests.cs
+++ b/test/QuizData.Parser.Test/CsvParserTests.cs
@@ -82,8 +82,9 @@ namespace QuizData.Parser.Tests
             using (var stream = new MemoryStream(bytes))
             {
                 var data = parser.ParseStream(stream);
-                Assert.Single(data);
-                var test = data.First();
+                var testResults = data.Take(2).ToArray();
+                Assert.Single(testResults);
+                var test = testResults[0];
 
                 Assert.Equal("email@site.com", test.Person.Email);
                 Assert.Equal("Иван", test.Person.Name);


### PR DESCRIPTION
Changed parser implementation to return an enumerable sequence instead of a list.
#4